### PR TITLE
feat: allow overriding power select component

### DIFF
--- a/addon/components/power-select-blockless.js
+++ b/addon/components/power-select-blockless.js
@@ -5,6 +5,12 @@ import layout from '../templates/components/power-select-blockless';
 export default Component.extend({
   layout: layout,
 
+  /**
+   * @property powerSelectComponent
+   * @type {String}
+   */
+  powerSelectComponent: 'power-select',
+
   // CPs
   searchField: computed('labelPath', function() {
     return this.get('labelPath');

--- a/addon/components/power-select-multiple-blockless.js
+++ b/addon/components/power-select-multiple-blockless.js
@@ -5,6 +5,12 @@ import layout from '../templates/components/power-select-multiple-blockless';
 export default Component.extend({
   layout: layout,
 
+  /**
+   * @property powerSelectMultipleComponent
+   * @type {String}
+   */
+  powerSelectMultipleComponent: 'power-select-multiple',
+
   // CPs
   searchField: computed('labelPath', function() {
     return this.get('labelPath');

--- a/addon/templates/components/power-select-blockless.hbs
+++ b/addon/templates/components/power-select-blockless.hbs
@@ -1,5 +1,5 @@
 {{#if labelPath}}
-  {{#power-select
+  {{#component powerSelectComponent
       afterOptionsComponent=afterOptionsComponent
       allowClear=allowClear
       ariaDescribedBy=ariaDescribedBy
@@ -54,9 +54,9 @@
       as |option|}}
 
       {{get option labelPath}}
-  {{/power-select}}
+  {{/component}}
 {{else}}
-  {{#power-select
+  {{#component powerSelectComponent
       afterOptionsComponent=afterOptionsComponent
       allowClear=allowClear
       ariaDescribedBy=ariaDescribedBy
@@ -111,5 +111,5 @@
       as |option|}}
 
       {{option}}
-  {{/power-select}}
+  {{/component}}
 {{/if}}

--- a/addon/templates/components/power-select-multiple-blockless.hbs
+++ b/addon/templates/components/power-select-multiple-blockless.hbs
@@ -1,5 +1,5 @@
 {{#if labelPath}}
-  {{#power-select-multiple
+  {{#component powerSelectMultipleComponent
       afterOptionsComponent=afterOptionsComponent
       allowClear=allowClear
       ariaDescribedBy=ariaDescribedBy
@@ -54,9 +54,9 @@
       as |option|}}
 
       {{get option labelPath}}
-  {{/power-select-multiple}}
+  {{/component}}
 {{else}}
-  {{#power-select-multiple
+  {{#component powerSelectMultipleComponent
       afterOptionsComponent=afterOptionsComponent
       allowClear=allowClear
       ariaDescribedBy=ariaDescribedBy
@@ -111,5 +111,5 @@
       as |option|}}
 
       {{option}}
-  {{/power-select-multiple}}
+  {{/component}}
 {{/if}}


### PR DESCRIPTION
Similar in scope to https://github.com/kaliber5/ember-bootstrap/pull/685 & https://github.com/kaliber5/ember-bootstrap-power-select/pull/63

Basically allows overriding which `power-select` components the `ember-power-select-blockless` uses when we're locally extending `ember-power-select-blockless` components.

This is useful when using some custom extended power-select components - for example if there's some internal `my-power-select` variant in the consuming app which we'd like to be used by `ember-power-select-blockless`.